### PR TITLE
Fix typo in HttpPostHandler docstring

### DIFF
--- a/src/diamond/handler/httpHandler.py
+++ b/src/diamond/handler/httpHandler.py
@@ -12,7 +12,7 @@ Send metrics to a http endpoint via POST
 #### Configuration
 Enable this handler
 
- * handers = diamond.handler.httpHandler.HttpPostHandler
+ * handlers = diamond.handler.httpHandler.HttpPostHandler
 
  * url = http://www.example.com/endpoint
 


### PR DESCRIPTION
Because copypasting lines from wiki to configuration file should work.